### PR TITLE
[WIP] Generate preshared pairs on export

### DIFF
--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -12,6 +12,9 @@ import copy
 import json
 import pathlib
 import sys
+import hashlib
+import json
+import itertools
 
 # third party imports
 from prettytable import PrettyTable
@@ -251,6 +254,10 @@ class DatabaseManager:
             print(f"Creating output directory: {output}")
             output.mkdir(exist_ok=True)
 
+        preshared_keys = {}
+        for _combo_pair in itertools.combinations(peers, 2):
+            preshared_keys[json.dumps(sorted(list(_combo_pair)))] = self.wireguard.genpsk()
+
         # for every peer in the database
         for peer in peers:
             with (output / f"{peer}.conf").open("w") as config:
@@ -278,6 +285,12 @@ class DatabaseManager:
                     config.write(
                         "PublicKey = {}\n".format(
                             self.wireguard.pubkey(database["peers"][p]["PrivateKey"])
+                        )
+                    )
+
+                    config.write(
+                        "PresharedKey = {}\n".format(
+                            preshared_keys[json.dumps(sorted(list({peer, p})))]
                         )
                     )
 

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -12,8 +12,6 @@ import copy
 import json
 import pathlib
 import sys
-import hashlib
-import json
 import itertools
 
 # third party imports


### PR DESCRIPTION
To fix #10 
(this is purposefully Draft, as it requires some adjustments before it can suit real use)

This is very brief change that is targeted towards creation of preshared keys that are shared with each pair of nodes to further enhance security. Worth to mention that preshared key is apparently used *always* anyway, but in default state just defaulted to all 0s.

> If an additional layer of symmetric-key crypto is required (for, say, post-quantum resistance), WireGuard also supports an optional pre-shared key that is mixed into the public key cryptography. When pre-shared key mode is not in use, the pre-shared key value used below is assumed to be an all-zero string of 32 bytes.

Taken from https://www.wireguard.com/protocol/

Tl;dr about what this ugly code does during export:
1. Calculate possible unique pairs (permutations) between all configured peers
2. Generate preshared keys and store them in hashmap with key as single permutation - JSON serialized sorted list (to exclude cases `['a','b']` and `['b','a']`)
3. Lookup keys from hashmap during export, and plug them in.

What should probably be improved in this PR before merging it in (if ever):
1. This has to be made optional
2. It could be theoretically be calculated on adding peers, however, the amount of preshared keys is changing not linearly. (I don't know if anyone is planning to use this for mesh of thousands of nodes... or maybe?), so instead I opted for "on export".
3. Due to not going with 2, it generates all pairs of preshared keys on export, so not persisted anywhere (ex. database file), so not easily "adjustable" when u need to add more peers. Perhaps, database option could be improved.
4. Code is ugly, perhaps there's better way, but I wrote it in rush and as long as it works (it does)...