### PR TITLE
Support persistent-keepalive parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Specify `-h` or `--help` after a command to see this command's usages.
 
 ```shell
 $ wg-meshconf addpeer -h
-usage: wg-meshconf addpeer [-h] --address ADDRESS [--endpoint ENDPOINT] [--privatekey PRIVATEKEY] [--listenport LISTENPORT] [--fwmark FWMARK] [--dns DNS] [--mtu MTU] [--table TABLE] [--preup PREUP] [--postup POSTUP] [--predown PREDOWN] [--postdown POSTDOWN] [--saveconfig] name
+usage: wg-meshconf addpeer [-h] --address ADDRESS [--endpoint ENDPOINT] [--allowedips ALLOWEDIPS] [--privatekey PRIVATEKEY] [--listenport LISTENPORT] [--fwmark FWMARK] [--dns DNS] [--mtu MTU] [--table TABLE] [--preup PREUP] [--postup POSTUP] [--predown PREDOWN] [--postdown POSTDOWN] [--keepalive KEEPALIVE] [--saveconfig] name
 
 positional arguments:
   name                  Name used to identify this node
@@ -203,6 +203,8 @@ optional arguments:
   -h, --help            show this help message and exit
   --address ADDRESS     address of the server
   --endpoint ENDPOINT   peer's public endpoint address
+  --allowedips ALLOWEDIPS
+                        additional allowed IP addresses
   --privatekey PRIVATEKEY
                         private key of server interface
   --listenport LISTENPORT
@@ -215,6 +217,8 @@ optional arguments:
   --postup POSTUP       command to run after interface is up
   --predown PREDOWN     command to run before interface is down
   --postdown POSTDOWN   command to run after interface is down
+  --keepalive KEEPALIVE
+                        send keepalive packets every n seconds
   --saveconfig          save server interface to config upon shutdown
 ```
 

--- a/wg_meshconf/database_manager.py
+++ b/wg_meshconf/database_manager.py
@@ -104,6 +104,7 @@ class DatabaseManager:
         PostUp: str = None,
         PreDown: str = None,
         PostDown: str = None,
+        PersistentKeepalive: int = None,
         SaveConfig: bool = None,
     ):
         database = copy.deepcopy(self.database_template)
@@ -142,6 +143,7 @@ class DatabaseManager:
         PostUp: str = None,
         PreDown: str = None,
         PostDown: str = None,
+        PersistentKeepalive: int = None,
         SaveConfig: bool = None,
     ):
         database = copy.deepcopy(self.database_template)
@@ -303,3 +305,10 @@ class DatabaseManager:
                         else:
                             allowed_ips = ", ".join(database["peers"][p]["Address"])
                         config.write("AllowedIPs = {}\n".format(allowed_ips))
+
+                    if database["peers"][p].get("PersistentKeepalive") is not None:
+                        config.write(
+                            "PersistentKeepalive = {}\n".format(
+                                database["peers"][p]["PersistentKeepalive"],
+                            )
+                        )

--- a/wg_meshconf/wg_meshconf.py
+++ b/wg_meshconf/wg_meshconf.py
@@ -60,6 +60,7 @@ def parse_arguments():
     addpeer.add_argument("--postup", help="command to run after interface is up")
     addpeer.add_argument("--predown", help="command to run before interface is down")
     addpeer.add_argument("--postdown", help="command to run after interface is down")
+    addpeer.add_argument("--keepalive", help="send keepalive packets every n seconds")
     addpeer.add_argument(
         "--saveconfig",
         action="store_true",
@@ -85,6 +86,7 @@ def parse_arguments():
     updatepeer.add_argument("--postup", help="command to run after interface is up")
     updatepeer.add_argument("--predown", help="command to run before interface is down")
     updatepeer.add_argument("--postdown", help="command to run after interface is down")
+    updatepeer.add_argument("--keepalive", help="send keepalive packets every n seconds")
     updatepeer.add_argument(
         "--saveconfig",
         action="store_true",
@@ -158,6 +160,7 @@ def main():
             args.postup,
             args.predown,
             args.postdown,
+            args.keepalive,
             args.saveconfig,
         )
 
@@ -177,6 +180,7 @@ def main():
             args.postup,
             args.predown,
             args.postdown,
+            args.keepalive,
             args.saveconfig,
         )
 


### PR DESCRIPTION
As mentioned in #17 

Introduces the --keepalive argument for addpeer and updatepeer that maps
to the PersistenKeepalive parameter of the configuration file.
In order to disable the keepalive, set the parameter to 0. This will not
remove the entry from the database, but will explicitly write the value
to the configuration.